### PR TITLE
스프링 타입 컨버터 소개

### DIFF
--- a/typeconverter/src/main/java/hello/typeconverter/controller/HelloController.java
+++ b/typeconverter/src/main/java/hello/typeconverter/controller/HelloController.java
@@ -1,0 +1,25 @@
+package hello.typeconverter.controller;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.servlet.http.HttpServletRequest;
+
+@RestController
+public class HelloController {
+
+    @GetMapping("/hello-v1")
+    public String helloV1(HttpServletRequest request) {
+        String data = request.getParameter("data"); // 문자 타입 조회
+        Integer intValue = Integer.valueOf(data);   // 숫자 타입으로 변경
+        System.out.println("intValue = " + data);
+        return "ok";
+    }
+
+    @GetMapping("/hello-v2")
+    public String helloV2(@RequestParam Integer data) {
+        System.out.println("data = " + data);
+        return "ok";
+    }
+}


### PR DESCRIPTION
### 문자를 숫자로 변환하거나, 반대로 숫자를 문자로 변환해야 하는 것 처럼 애플리케이션을 개발하다 보면
타입을 변환해야 하는 경우가 상당히 많다.

![image](https://user-images.githubusercontent.com/86340380/197458339-0b199965-9bbb-46d4-b3e3-b4543d1ea7d8.png)

**분석**
- String data = request.getParameter("data")
HTTP 요청 파라미터는 모두 문자로 처리된다. 따라서 요청 파라미터를 자바에서 다른 타입으로 변환해서 사용하고 싶으면 다음과 같이 숫자 타입으로 변환하는 과정을 거쳐야 한다. 
Integer intValue = Integer.valueOf(data)

![image](https://user-images.githubusercontent.com/86340380/197458449-f8db1c1d-9490-4d7f-a2b1-a9909940e162.png)

앞서 보았듯이 HTTP 쿼리 스트링으로 전달하는 data=10 부분에서 10은 숫자 10이 아니라 문자 10이다. 스프링이 제공하는 @RequestParam 을 사용하면 이 문자 10을 Integer 타입의 숫자 10으로 편리하게 받을 수 있다.
**이것은 스프링이 중간에서 타입을 변환해주었기 때문이다.**

![image](https://user-images.githubusercontent.com/86340380/197458555-dd8ed851-20aa-4bd1-8e1a-19d8a3348c21.png)
@RequestParam 와 같이, 문자 data=10 을 숫자 10으로 받을 수 있다.

![image](https://user-images.githubusercontent.com/86340380/197458599-f0f283da-205a-424f-b073-345080ca3891.png)
URL 경로는 문자다. /users/10 여기서 10도 숫자 10이 아니라 그냥 문자 "10"이다. data를 Integer
타입으로 받을 수 있는 것도 스프링이 타입 변환을 해주기 때문이다.


### 스프링과 타입 변환
![image](https://user-images.githubusercontent.com/86340380/197458693-cf6b6cdb-35d6-479d-9355-c1b166c9929f.png)

스프링은 확장 가능한 컨버터 인터페이스를 제공한다.
개발자는 스프링에 추가적인 타입 변환이 필요하면 이 컨버터 인터페이스를 구현해서 등록하면 된다. 이 컨버터 인터페이스는 모든 타입에 적용할 수 있다. 필요하면 X Y 타입으로 변환하는 컨버터 인터페이스를 만들고, 또 Y X 타입으로 변환하는 컨버터 인터페이스를 만들어서 등록하면 된다.
예를 들어서 문자로 **"true"** 가 오면 **Boolean** 타입으로 받고 싶으면 **String Boolean** 타입으로 변환되도록 컨버터 인터페이스를 만들어서 등록하고, 반대로 적용하고 싶으면 **Boolean String** 타입으로 변환되도록 컨버터를 추가로 만들어서 등록하면 된다.