### PR TITLE
포맷터 - Formatter

### DIFF
--- a/typeconverter/src/main/java/hello/typeconverter/formatter/MyNumberFormatter.java
+++ b/typeconverter/src/main/java/hello/typeconverter/formatter/MyNumberFormatter.java
@@ -1,0 +1,25 @@
+package hello.typeconverter.formatter;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.format.Formatter;
+
+import java.text.NumberFormat;
+import java.text.ParseException;
+import java.util.Locale;
+
+@Slf4j
+public class MyNumberFormatter implements Formatter<Number> {
+
+    @Override
+    public Number parse(String text, Locale locale) throws ParseException {
+        log.info("text={}, locale={}", text, locale);
+        NumberFormat format = NumberFormat.getInstance(locale);
+        return format.parse(text);
+    }
+
+    @Override
+    public String print(Number object, Locale locale) {
+        log.info("object={}, locale={}", object, locale);
+        return NumberFormat.getInstance(locale).format(object);
+    }
+}

--- a/typeconverter/src/test/java/hello/typeconverter/formatter/MyNumberFormatterTest.java
+++ b/typeconverter/src/test/java/hello/typeconverter/formatter/MyNumberFormatterTest.java
@@ -1,0 +1,26 @@
+package hello.typeconverter.formatter;
+
+import org.junit.jupiter.api.Test;
+
+import java.text.ParseException;
+import java.util.Locale;
+
+import static org.assertj.core.api.Assertions.*;
+
+class MyNumberFormatterTest {
+
+    MyNumberFormatter formatter = new MyNumberFormatter();
+
+    @Test
+    void parse() throws ParseException {
+        Number result = formatter.parse("1,000", Locale.KOREA);
+        assertThat(result).isEqualTo(1000L);    // Long 타입 주의
+    }
+
+    @Test
+    void print() {
+        String result = formatter.print(1000, Locale.KOREA);
+        assertThat(result).isEqualTo("1,000");
+    }
+
+}


### PR DESCRIPTION
###  애플리케이션에서 객체를 문자로, 문자를 객체로 변환하는 예
- 화면에 숫자를 출력해야 하는데, Integer String 출력 시점에 숫자 1000 문자 "1,000" 이렇게 1000 단위에 쉼표를 넣어서 출력하거나, 또는 "1,000" 라는 문자를 1000 이라는 숫자로 변경해야 한다.
- 날짜 객체를 문자인 "2021-01-01 10:50:11" 와 같이 출력하거나 또는 그 반대의 상황

### Locale
여기에 추가로 날짜 숫자의 표현 방법은 Locale 현지화 정보가 사용될 수 있다.

이렇게 객체를 특정한 포멧에 맞추어 문자로 출력하거나 또는 그 반대의 역할을 하는 것에 특화된 기능이
바로 포맷터( Formatter )이다. 포맷터는 컨버터의 특별한 버전으로 이해하면 된다.

### Converter vs Formatter
- Converter 는 범용(객체 객체)
- Formatter 는 문자에 특화(객체 문자, 문자 객체) + 현지화(Locale)
- Converter 의 특별한 버전

## 포맷터 - Formatter 만들기
포맷터( Formatter )는 객체를 문자로 변경하고, 문자를 객체로 변경하는 두 가지 기능을 모두 수행한다.

- String print(T object, Locale locale) : 객체를 문자로 변경한다.
- T parse(String text, Locale locale) : 문자를 객체로 변경한다.

**숫자 1000 을 문자 "1,000" 으로 그러니까, 1000 단위로 쉼표가 들어가는 포맷을 적용해보자. 그리고 그 반대도 처리해주는 포맷터를 만들어보자.**

![image](https://user-images.githubusercontent.com/86340380/198511795-728b7325-e3ab-43b4-a61d-22ff3b07ea44.png)

- "1,000" 처럼 숫자 중간의 쉼표를 적용하려면 자바가 기본으로 제공하는 NumberFormat 객체를 사용하면 된다. 이 객체는 Locale 정보를 활용해서 나라별로 다른 숫자 포맷을 만들어준다.
- parse() 를 사용해서 문자를 숫자로 변환한다. 참고로 Number 타입은 Integer , Long 과 같은 숫자 타입의 부모 클래스이다.
- print() 를 사용해서 객체를 문자로 변환한다.


테스트 코드를 활용하여 확인해보자

![image](https://user-images.githubusercontent.com/86340380/198511991-7189825f-79e7-4c32-8924-b6f109edd283.png)

![image](https://user-images.githubusercontent.com/86340380/198512024-2c15e1b3-b855-42a0-b51e-373a1395dfa0.png)



