### PR TITLE
포맷터를 지원하는 컨버전 서비스

### DIFF
--- a/typeconverter/src/main/java/hello/typeconverter/WebConfig.java
+++ b/typeconverter/src/main/java/hello/typeconverter/WebConfig.java
@@ -4,6 +4,7 @@ import hello.typeconverter.converter.IntegerToStringConverter;
 import hello.typeconverter.converter.IpPortToStringConverter;
 import hello.typeconverter.converter.StringToIntegerConverter;
 import hello.typeconverter.converter.StringToIpPortConverter;
+import hello.typeconverter.formatter.MyNumberFormatter;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.format.FormatterRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
@@ -13,9 +14,13 @@ public class WebConfig implements WebMvcConfigurer {
 
     @Override
     public void addFormatters(FormatterRegistry registry) {
-        registry.addConverter(new StringToIntegerConverter());
-        registry.addConverter(new IntegerToStringConverter());
+//        주석처리 우선순위
+//        registry.addConverter(new StringToIntegerConverter());
+//        registry.addConverter(new IntegerToStringConverter());
         registry.addConverter(new StringToIpPortConverter());
         registry.addConverter(new IpPortToStringConverter());
+
+        //추가
+        registry.addFormatter(new MyNumberFormatter());
     }
 }

--- a/typeconverter/src/test/java/hello/typeconverter/formatter/FormattingConversionServiceTest.java
+++ b/typeconverter/src/test/java/hello/typeconverter/formatter/FormattingConversionServiceTest.java
@@ -1,0 +1,33 @@
+package hello.typeconverter.formatter;
+
+import hello.typeconverter.converter.IpPortToStringConverter;
+import hello.typeconverter.converter.StringToIpPortConverter;
+import hello.typeconverter.type.IpPort;
+import org.junit.jupiter.api.Test;
+import org.springframework.format.support.DefaultFormattingConversionService;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class FormattingConversionServiceTest {
+
+    @Test
+    void formattingConversionService() {
+
+        DefaultFormattingConversionService conversionService = new DefaultFormattingConversionService();
+
+        // 컨버터 등록
+        conversionService.addConverter(new StringToIpPortConverter());
+        conversionService.addConverter(new IpPortToStringConverter());
+
+        //포멧터 등록
+        conversionService.addFormatter(new MyNumberFormatter());
+
+        //컨버터 사용
+        IpPort ipPort = conversionService.convert("127.0.0.1:8080", IpPort.class);
+        assertThat(ipPort).isEqualTo(new IpPort("127.0.0.1", 8080));
+
+        //포멧터 사용
+        assertThat(conversionService.convert(1000, String.class)).isEqualTo("1,000");
+        assertThat(conversionService.convert("1,000", Long.class)).isEqualTo(1000L);
+    }
+}


### PR DESCRIPTION
컨버전 서비스에는 컨버터만 등록할 수 있고, 포맷터를 등록할 수 는 없다. 그런데 생각해보면 포맷터는 객체 문자, 문자 객체로 변환하는 특별한 컨버터일 뿐이다.
포맷터를 지원하는 컨버전 서비스를 사용하면 컨버전 서비스에 포맷터를 추가할 수 있다. 내부에서 어댑터 패턴을 사용해서 **Formatter** 가 **Converter** 처럼 동작하도록 지원한다.


**FormattingConversionService** 는 포맷터를 지원하는 컨버전 서비스이다.
**DefaultFormattingConversionService** 는 **FormattingConversionService** 에 기본적인 통화, 숫자 관련 몇가지 기본 포맷터를 추가해서 제공한다.


### DefaultFormattingConversionService 상속 관계
**FormattingConversionService** 는 **ConversionService** 관련 기능을 상속받기 때문에 결과적으로 컨버터도 포맷터도 모두 등록할 수 있다. 그리고 사용할 때는 **ConversionService** 가 제공하는 convert 를 사용하면 된다.

추가로 스프링 부트는 **DefaultFormattingConversionService** 를 상속 받은 **WebConversionService** 를 내부에서 사용한다.


## 포맷터 적용하기

**WebConfig - 수정**
![image](https://user-images.githubusercontent.com/86340380/198518515-0d87f335-52ee-490e-8cfc-8758d0a5a15c.png)

**주의** StringToIntegerConverter , IntegerToStringConverter 를 꼭 주석처리 하자.
MyNumberFormatter 도 숫자 문자, 문자 숫자로 변경하기 때문에 둘의 기능이 겹친다. 우선순위는 컨버터가 우선하므로 포맷터가 적용되지 않고, 컨버터가 적용된다.

**실행 - 객체 문자**
http://localhost:8080/converter-view

• ${number}: 10000
• ${{number}}: 10,000

== 컨버전 서비스를 적용한 결과 MyNumberFormatter 가 적용되어서 10,000 문자가 출력된 것을 확인할 수 있다.


**실행 - 문자 객체**
http://localhost:8080/hello-v2?data=10,000

**실행 로그**
MyNumberFormatter : text=10,000, locale=ko_KR
data = 10000

== "10,000" 이라는 포맷팅 된 문자가 Integer 타입의 숫자 10000으로 정상 변환 된 것을 확인할 수 있다.


